### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,6 +1,9 @@
 name: Python Test with Minikube
 
 on: [push, pull_request]
+
+permissions:
+  contents: read
     
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/corvusfaber/node-temp/security/code-scanning/11](https://github.com/corvusfaber/node-temp/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with repository contents and uploads artifacts, the `contents: read` permission is sufficient. If additional permissions are required for specific jobs, they can be defined within those jobs.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` has restricted access throughout the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
